### PR TITLE
Fija el máximo de X para que sea consistente

### DIFF
--- a/Piramide_poblacional.R
+++ b/Piramide_poblacional.R
@@ -52,7 +52,7 @@ saveGIF(
     mujeres <- as.vector(unlist(mujeres$Mujeres))
     mujeres <- (mujeres/sum(mujeres)) *100
     
-    par(mar=pyramid.plot( hombres, mujeres, labels=agelabels,lxcol=mcol,rxcol=fcol,show.values=TRUE))
+    par(mar=pyramid.plot( hombres, mujeres, labels=agelabels,lxcol=mcol,rxcol=fcol,show.values=TRUE, xlim=c(12,12)))
     title(paste0("Pirámide poblacional de España año ",year),cex.sub=1.7)
   },
   interval=1,


### PR DESCRIPTION
Con el código original, el máximo del eje X puede cambiar entre fotogramas, lo que hace más difícil apreciar ciertos cambios y puede falsear algunas observaciones (por ejemplo, puede parecer que los nacimientos aumentan).

Este parche fija el máximo de X en todos los fotogramas, de manera que todos son comparables entre sí y se mantiene la consistencia de escala entre todos ellos.